### PR TITLE
✨ Implement AddFlagWithFunc()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,85 @@
 Importable package that parses `debug.ReadBuildInfo()` for inclusion in your Go application.
 
 Requires Go 1.18+ for Git revision information, but compatible with prior versions of Go.
+
+## Examples
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    fmt.Println("Version:", versioninfo.Version)
+    fmt.Println("Revision:", versioninfo.Revision)
+    fmt.Println("DirtyBuild:", versioninfo.DirtyBuild)
+    fmt.Println("LastCommit:", versioninfo.LastCommit)
+}
+```
+
+You may use the concatenated information provided by `versioninfo.Short()`:
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    fmt.Println("ShortInfo:", versioninfo.Short())
+}
+```
+
+Add the `-v` and `-version` flags:
+
+```go
+package main
+
+import (
+    "flag"
+    "fmt"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    versioninfo.AddFlag(nil)
+    flag.Parse()
+    fmt.Println("done")
+}
+```
+
+Customize your `-version` print:
+
+```go
+package main
+
+import (
+    "flag"
+    "fmt"
+    "os"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    versioninfo.AddFlagWithFunc(nil, myPrint)
+    flag.Parse()
+    fmt.Println("done")
+}
+
+func myPrint(b bool) error {
+    if b {
+        fmt.Println(versioninfo.Short())
+        os.Exit(0)
+    }
+    return nil
+}
+```

--- a/flag.go
+++ b/flag.go
@@ -12,13 +12,19 @@ import (
 // If triggered, the flags print version information and call os.Exit(0).
 // If FlagSet is nil, it adds the flags to flag.CommandLine.
 func AddFlag(f *flag.FlagSet) {
+	AddFlagWithFunc(f, printVersion)
+}
+
+// AddFlagWithFunc is like AddFlag but with a custom version-print function.
+func AddFlagWithFunc(f *flag.FlagSet, do func(b bool) error) {
 	if f == nil {
 		f = flag.CommandLine
 	}
-	f.Var(boolFunc(printVersion), "v", "short alias for -version")
-	f.Var(boolFunc(printVersion), "version", "print version information and exit")
+	f.Var(boolFunc(do), "v", "short alias for -version")
+	f.Var(boolFunc(do), "version", "print version information and exit")
 }
 
+// printVersion is the default version print.
 func printVersion(b bool) error {
 	if !b {
 		return nil


### PR DESCRIPTION
This PR to let the user customizes the `-version` print:

```go
package main

import "flag"
import "fmt"
import "os"
import "github.com/carlmjohnson/versioninfo"

func main() {
    versioninfo.AddFlagWithFunc(nil, myPrint)
    flag.Parse()
    fmt.Println("done")
}

func myPrint(b bool) error {
    if b {
        fmt.Println(versioninfo.Short())
        os.Exit(0)
    }
    return nil
}
```