### PR TITLE
✨ Make BoolFunc public to ease flags customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,85 @@
 Importable package that parses `debug.ReadBuildInfo()` for inclusion in your Go application.
 
 Requires Go 1.18+ for Git revision information, but compatible with prior versions of Go.
+
+## Examples
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    fmt.Println("Version:", versioninfo.Version)
+    fmt.Println("Revision:", versioninfo.Revision)
+    fmt.Println("DirtyBuild:", versioninfo.DirtyBuild)
+    fmt.Println("LastCommit:", versioninfo.LastCommit)
+}
+```
+
+You may use the concatenated information provided by `versioninfo.Short()`:
+
+```go
+package main
+
+import (
+    "fmt"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    fmt.Println("ShortInfo:", versioninfo.Short())
+}
+```
+
+Add the `-v` and `-version` flags:
+
+```go
+package main
+
+import (
+    "flag"
+    "fmt"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    versioninfo.AddFlag(nil)
+    flag.Parse()
+    fmt.Println("done")
+}
+```
+
+Customize your `-version` print:
+
+```go
+package main
+
+import (
+    "flag"
+    "fmt"
+    "os"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    versioninfo.AddFlagWithFunc(nil, myPrint)
+    flag.Parse()
+    fmt.Println("done")
+}
+
+func myPrint(b bool) error {
+    if b {
+        fmt.Println(versioninfo.Short())
+        os.Exit(0)
+    }
+    return nil
+}
+```

--- a/README.md
+++ b/README.md
@@ -85,3 +85,31 @@ func myPrint(b bool) error {
     return nil
 }
 ```
+
+Customize your flags, for example to set `-version` only:
+
+```go
+package main
+
+import (
+    "flag"
+    "fmt"
+    "os"
+
+    "github.com/carlmjohnson/versioninfo"
+)
+
+func main() {
+    f.Var(versioninfo.BoolFunc(myPrint), "version", "Print version and exit")
+    flag.Parse()
+    fmt.Println("done")
+}
+
+func myPrint(b bool) error {
+    if b {
+        fmt.Println(versioninfo.Short())
+        os.Exit(0)
+    }
+    return nil
+}
+```

--- a/flag.go
+++ b/flag.go
@@ -12,13 +12,19 @@ import (
 // If triggered, the flags print version information and call os.Exit(0).
 // If FlagSet is nil, it adds the flags to flag.CommandLine.
 func AddFlag(f *flag.FlagSet) {
+	AddFlagWithFunc(f, printVersion)
+}
+
+// AddFlagWithFunc is like AddFlag but with a custom version-print function.
+func AddFlagWithFunc(f *flag.FlagSet, do func(b bool) error) {
 	if f == nil {
 		f = flag.CommandLine
 	}
-	f.Var(boolFunc(printVersion), "v", "short alias for -version")
-	f.Var(boolFunc(printVersion), "version", "print version information and exit")
+	f.Var(boolFunc(do), "v", "short alias for -version")
+	f.Var(boolFunc(do), "version", "print version information and exit")
 }
 
+// printVersion is the default version print.
 func printVersion(b bool) error {
 	if !b {
 		return nil

--- a/flag.go
+++ b/flag.go
@@ -20,8 +20,8 @@ func AddFlagWithFunc(f *flag.FlagSet, do func(b bool) error) {
 	if f == nil {
 		f = flag.CommandLine
 	}
-	f.Var(boolFunc(do), "v", "short alias for -version")
-	f.Var(boolFunc(do), "version", "print version information and exit")
+	f.Var(BoolFunc(do), "v", "short alias for -version")
+	f.Var(BoolFunc(do), "version", "print version information and exit")
 }
 
 // printVersion is the default version print.
@@ -41,17 +41,18 @@ func printVersion(b bool) error {
 	panic("unreachable")
 }
 
-type boolFunc func(bool) error
+// BoolFunc allows to customize the command line flags.
+type BoolFunc func(bool) error
 
-func (f boolFunc) IsBoolFlag() bool {
+func (f BoolFunc) IsBoolFlag() bool {
 	return true
 }
 
-func (f boolFunc) String() string {
+func (f BoolFunc) String() string {
 	return ""
 }
 
-func (f boolFunc) Set(s string) error {
+func (f BoolFunc) Set(s string) error {
 	b, err := strconv.ParseBool(s)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR to ease the flags customization.
In the following example, only the flag `-version` is defined:
Please, accept PR https://github.com/carlmjohnson/versioninfo/pull/9 before this one.

```go
package main

import "flag"
import "fmt"
import "os"
import "github.com/carlmjohnson/versioninfo"

func main() {
    f.Var(versioninfo.BoolFunc(myPrint), "version", "Print version and exit")
    flag.Parse()
    fmt.Println("done")
}

func myPrint(b bool) error {
    if b {
        fmt.Println(versioninfo.Short())
        os.Exit(0)
    }
    return nil
}
```